### PR TITLE
Url fixes

### DIFF
--- a/protocol/forks/bch-uahf.md
+++ b/protocol/forks/bch-uahf.md
@@ -186,6 +186,6 @@ NOTE 2: This bit is currently referred to as NODE_BITCOIN_CASH and displayed as 
 
 [2] https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#Motivation
 
-[3] [Digest for replay protected signature verification accross hard forks](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md)
+[3] [Digest for replay protected signature verification accross hard forks](/protocol/network/messages/dsproof-beta)
 
 [4] https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/uahf-test-plan.md

--- a/protocol/network/messages/dsproof-beta.md
+++ b/protocol/network/messages/dsproof-beta.md
@@ -16,7 +16,7 @@ spending the same output. In the case of pay-to-public-key-hash (P2PKH)
 this means two signatures signing the same public key.
 
 Cryptographic signatures in Bitcoin Cash follow the 'fork-id' algorithm described
-[here](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md),
+[here](/protocol/forks/replay-protected-sighash),
 which explains a change made to the Satoshi designed algorithm, a change after which the containing transaction itself is not signed, but a unique hash of that
 transaction is being signed. This gives us the opportunity to send only
 the intermediate hashes instead of the whole transaction while allowing
@@ -95,7 +95,7 @@ To validate a spender of the proof, a node requires to have;
 * The double-spend-proof.
 
 As the forkid
-[specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md)
+[specification](/protocol/forks/replay-protected-sighash)
 details, the digest algorithm hashes 10 items in order to receive a sha256
 hash, which is then signed.
 

--- a/protocol/network/messages/inv.md
+++ b/protocol/network/messages/inv.md
@@ -38,5 +38,6 @@ The type of the object that is available.
 |   4  |  Compact block
 |   5  |  Xthin block (Bitcoin Unlimited)
 |   6  |  Graphene Block (Bitcoin Unlimited)
+| 0x94a0 | [DSProof](/protocol/network/messages/dsproof-beta) |
 
 Implementations: [C++](https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/eb264e627e231f7219e60eef41b4e37cc52d6d9d/src/protocol.h#L477)


### PR DESCRIPTION
stop linking to a remote repo when the local one will do