### PR TITLE
Update to create a note about VARINT/ vs Compact size potential ambiguity

### DIFF
--- a/protocol/formats/variable-length-integer.md
+++ b/protocol/formats/variable-length-integer.md
@@ -1,6 +1,8 @@
 # Compact Variable Length Integer
 
-A variable-width data format for unsigned integers allowing a more compact representation for smaller values.  This is sometimes referred to as "compact size" or "var int".
+A variable-width data format for unsigned integers allowing a more compact representation for smaller values.  This is sometimes referred to as "compact size" or "var int"\*.  
+
+\* - Caution should be used when refering to this integer format as "var int" (or "VarInt"), however, in that it may create an ambiguity.  The "Core" family of software (BCHN, BU, and Flowee) all have an internal "VARINT" format that is distinct from this integer format (this format is referred to as COMPACTSIZE or CompactSize in that lineage of software).  Perhaps one should refer to this as either "compact int" or "compact size" in order to avoid the potential ambiguity with respect to that VARINT format known to nodes that are descendants of Core.
 
 ## Format
 

--- a/protocol/formats/variable-length-integer.md
+++ b/protocol/formats/variable-length-integer.md
@@ -2,7 +2,7 @@
 
 A variable-width data format for unsigned integers allowing a more compact representation for smaller values.  This is sometimes referred to as "compact size" or "var int"\*.  
 
-\* - Caution should be used when refering to this integer format as "var int" (or "VarInt"), however, in that it may create an ambiguity.  The "Core" family of software (BCHN, BU, and Flowee) all have an internal "VARINT" format that is distinct from this integer format (this format is referred to as COMPACTSIZE or CompactSize in that lineage of software).  Perhaps one should refer to this as either "compact int" or "compact size" in order to avoid the potential ambiguity with respect to that VARINT format known to nodes that are descendants of Core.
+\* - Caution should be used when refering to this integer format as "var int" (or "VarInt"), however, in that it may create an ambiguity. The "Core" family of software (BCHN, BU, and Flowee) all have an internal "VARINT" format that is distinct from this integer format. In that "Core" lineage of software, COMPACTSIZE or CompactSize is used to refer to the protocol's variable length integer format, while "VarInt" refers specifically to their internal variable length integer format and is *not* a part of the Bitcoin Cash P2P protocol.
 
 ## Format
 


### PR DESCRIPTION
I only am being a pain about this to avoid headaches for people that are used to the Core line of node software where VARINT exists (internally) and is distinct from Compact size...